### PR TITLE
Use $.find() instead of getElementById()

### DIFF
--- a/jquery.onAvailable-1.0.js
+++ b/jquery.onAvailable-1.0.js
@@ -156,7 +156,7 @@
       /**
        * Fire the listener's callback function
        */
-      listener.callback.call(scope, listener.obj);
+      listener.callback.call(scope, listener, listener.obj);
     },
 
 
@@ -182,7 +182,7 @@
         /**
          * Attempt to find the specified element in the DOM
          */
-        var el = document.getElementById(listener.id);
+        var el = $(listener.id);
 
         /**
          * If the DOM element is found, execute callbacks for all related


### PR DESCRIPTION
$.find() is much more powerful and available since this is a JQuery plugin. Additionally I added found node to the callback call. It's the clean way to find out which of node in a set returned by $.find() we are dealing with right now.

``` javascript
$.onAvailable(".paragraph", function(node, obj){
    console.log(node)
    console.log(obj)
})
```
